### PR TITLE
Use lowercase in require directive

### DIFF
--- a/lib/mandrill_template/cli.rb
+++ b/lib/mandrill_template/cli.rb
@@ -5,7 +5,7 @@ require 'formatador'
 require 'unicode' unless ['jruby'].include?(RbConfig::CONFIG['ruby_install_name'])
 require 'yaml'
 require "mandrill_template/monkey_create_file"
-require 'IMGKit'
+require 'imgkit'
 require 'erb'
 autoload "Handlebars", 'handlebars'
 


### PR DESCRIPTION
Because Linux is case-sensitive we've got following error:

```
Step 8/8 : RUN bundle exec mandrilltemplate report
 ---> Running in cf2416851715
[91mLoadError: cannot load such file -- IMGKit
  /usr/local/bundle/bundler/gems/mandrill-template-manager-7be1b90b7f24/lib/mandrill_template/cli.rb:8:in `require'
  /usr/local/bundle/bundler/gems/mandrill-template-manager-7be1b90b7f24/lib/mandrill_template/cli.rb:8:in `<top (required)>'
  /usr/local/bundle/bundler/gems/mandrill-template-manager-7be1b90b7f24/bin/mandrilltemplate:6:in `require'
  /usr/local/bundle/bundler/gems/mandrill-template-manager-7be1b90b7f24/bin/mandrilltemplate:6:in `<top (required)>'
  /usr/local/bundle/bin/mandrilltemplate:29:in `load'
  /usr/local/bundle/bin/mandrilltemplate:29:in `<top (required)>'
[0mbundler: failed to load command: mandrilltemplate (/usr/local/bundle/bin/mandrilltemplate)
```

Lowercasing module name in require directive fixes this issue.